### PR TITLE
Enable Shader Model 3 across vertex shaders

### DIFF
--- a/vertex_program/2d.vsh
+++ b/vertex_program/2d.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/2d_distort.vsh
+++ b/vertex_program/2d_distort.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/2d_distort_vs11.vsh
+++ b/vertex_program/2d_distort_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/2d_texture.vsh
+++ b/vertex_program/2d_texture.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_2blend_decal_vs11.vsh
+++ b/vertex_program/a_2blend_decal_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetDTLA	textureCoordinateSet0
 #define textureCoordinateSetDTLB	textureCoordinateSet1

--- a/vertex_program/a_2blend_decal_vs20.vsh
+++ b/vertex_program/a_2blend_decal_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetDTLA	textureCoordinateSet0
 #define textureCoordinateSetDTLB	textureCoordinateSet1

--- a/vertex_program/a_2blend_dirt_bump_ps11_pass1.vsh
+++ b/vertex_program/a_2blend_dirt_bump_ps11_pass1.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetDTLA	textureCoordinateSet0
 #define textureCoordinateSetDTLB	textureCoordinateSet1

--- a/vertex_program/a_2blend_dirt_bump_ps20.vsh
+++ b/vertex_program/a_2blend_dirt_bump_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetDTLA	textureCoordinateSet0
 #define textureCoordinateSetDTLB	textureCoordinateSet1

--- a/vertex_program/a_2blend_dirt_bump_vs11_for_ps11.vsh
+++ b/vertex_program/a_2blend_dirt_bump_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetDTLA	textureCoordinateSet0
 #define textureCoordinateSetDTLB	textureCoordinateSet1

--- a/vertex_program/a_2blend_dirt_bump_vs20_for_ps20.vsh
+++ b/vertex_program/a_2blend_dirt_bump_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetDTLA	textureCoordinateSet0
 #define textureCoordinateSetDTLB	textureCoordinateSet1

--- a/vertex_program/a_2blend_dirt_vs11_for_ps11.vsh
+++ b/vertex_program/a_2blend_dirt_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetDTLA	textureCoordinateSet0
 #define textureCoordinateSetDTLB	textureCoordinateSet1

--- a/vertex_program/a_2blend_dirt_vs11_for_ps11_pass2.vsh
+++ b/vertex_program/a_2blend_dirt_vs11_for_ps11_pass2.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetDTLA	textureCoordinateSet0
 #define textureCoordinateSetDIRT	textureCoordinateSet1

--- a/vertex_program/a_2blend_dirt_vs20_for_ps20.vsh
+++ b/vertex_program/a_2blend_dirt_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetDTLA	textureCoordinateSet0
 #define textureCoordinateSetDTLB	textureCoordinateSet1

--- a/vertex_program/a_2blend_specmap_dirt_aniso_vs20.vsh
+++ b/vertex_program/a_2blend_specmap_dirt_aniso_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetDTLA	textureCoordinateSet0
 #define textureCoordinateSetDTLB	textureCoordinateSet1

--- a/vertex_program/a_2blend_specmap_dirt_aniso_vs20_nodot3.vsh
+++ b/vertex_program/a_2blend_specmap_dirt_aniso_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetDTLA	textureCoordinateSet0
 #define textureCoordinateSetDTLB	textureCoordinateSet1

--- a/vertex_program/a_2blend_specmap_dirt_vs20.vsh
+++ b/vertex_program/a_2blend_specmap_dirt_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetDTLA	textureCoordinateSet0
 #define textureCoordinateSetDTLB	textureCoordinateSet1

--- a/vertex_program/a_2blend_specmap_dirt_vs20_nodot3.vsh
+++ b/vertex_program/a_2blend_specmap_dirt_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetDTLA	textureCoordinateSet0
 #define textureCoordinateSetDTLB	textureCoordinateSet1

--- a/vertex_program/a_2blend_vs11.vsh
+++ b/vertex_program/a_2blend_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetDTLA	textureCoordinateSet0
 #define textureCoordinateSetDTLB	textureCoordinateSet1

--- a/vertex_program/a_2blend_vs20.vsh
+++ b/vertex_program/a_2blend_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetDTLA	textureCoordinateSet0
 #define textureCoordinateSetDTLB	textureCoordinateSet1

--- a/vertex_program/a_3uv_blend_vs11.vsh
+++ b/vertex_program/a_3uv_blend_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDCAL	textureCoordinateSet1

--- a/vertex_program/a_3uv_blend_vs20.vsh
+++ b/vertex_program/a_3uv_blend_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDCAL	textureCoordinateSet1

--- a/vertex_program/a_alpha_emismap_vs11.vsh
+++ b/vertex_program/a_alpha_emismap_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_alpha_envmask_vs11.vsh
+++ b/vertex_program/a_alpha_envmask_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_bloom_mask_pass_vs20.vsh
+++ b/vertex_program/a_bloom_mask_pass_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_colorvertex.vsh
+++ b/vertex_program/a_colorvertex.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_detail_bump_vs11_for_ps11.vsh
+++ b/vertex_program/a_detail_bump_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/a_detail_bump_vs20_for_ps20.vsh
+++ b/vertex_program/a_detail_bump_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/a_detail_dirt_bump_vs20.vsh
+++ b/vertex_program/a_detail_dirt_bump_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/a_detail_dirt_vs11.vsh
+++ b/vertex_program/a_detail_dirt_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_detail_dirt_vs20.vsh
+++ b/vertex_program/a_detail_dirt_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_detail_specmap_aniso_vs11.vsh
+++ b/vertex_program/a_detail_specmap_aniso_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_detail_specmap_aniso_vs20_nodot3.vsh
+++ b/vertex_program/a_detail_specmap_aniso_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_detail_specmap_bump_vs20_for_ps20.vsh
+++ b/vertex_program/a_detail_specmap_bump_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_detail_specmap_emismap_vs11.vsh
+++ b/vertex_program/a_detail_specmap_emismap_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_detail_specmap_emismap_vs20_nodot3.vsh
+++ b/vertex_program/a_detail_specmap_emismap_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_detail_specmap_vs11_for_ps11.vsh
+++ b/vertex_program/a_detail_specmap_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_detail_specmap_vs20_for_ps20.vsh
+++ b/vertex_program/a_detail_specmap_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_detail_specmap_vs20_nodot3.vsh
+++ b/vertex_program/a_detail_specmap_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_detail_vs11.vsh
+++ b/vertex_program/a_detail_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_detail_vs20_for_ps20.vsh
+++ b/vertex_program/a_detail_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_emis_full_bloom_vs20.vsh
+++ b/vertex_program/a_emis_full_bloom_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_emis_full_ps11.vsh
+++ b/vertex_program/a_emis_full_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_envmask_bump_vs20_for_ps20.vsh
+++ b/vertex_program/a_envmask_bump_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/a_envmask_spec_bump_vs20.vsh
+++ b/vertex_program/a_envmask_spec_bump_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/a_envmask_spec_vs11_for_ps11.vsh
+++ b/vertex_program/a_envmask_spec_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_envmask_spec_vs20_for_ps20.vsh
+++ b/vertex_program/a_envmask_spec_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_envmask_spec_vs20_nodot3.vsh
+++ b/vertex_program/a_envmask_spec_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_envmask_specmap_aniso_vs11.vsh
+++ b/vertex_program/a_envmask_specmap_aniso_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_envmask_specmap_aniso_vs20.vsh
+++ b/vertex_program/a_envmask_specmap_aniso_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_envmask_specmap_aniso_vs20_nodot3.vsh
+++ b/vertex_program/a_envmask_specmap_aniso_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_envmask_specmap_detail_vs11_for_ps11.vsh
+++ b/vertex_program/a_envmask_specmap_detail_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_envmask_specmap_detail_vs20_for_ps20.vsh
+++ b/vertex_program/a_envmask_specmap_detail_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_envmask_specmap_detail_vs20_nodot3.vsh
+++ b/vertex_program/a_envmask_specmap_detail_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_envmask_specmap_vs11_for_ps11.vsh
+++ b/vertex_program/a_envmask_specmap_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_envmask_vs11_for_ps11.vsh
+++ b/vertex_program/a_envmask_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_envmask_vs20_for_ps20.vsh
+++ b/vertex_program/a_envmask_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_lava_alpha_vs11.vsh
+++ b/vertex_program/a_lava_alpha_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_lava_envmask_vs11.vsh
+++ b/vertex_program/a_lava_envmask_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/a_lava_vs11.vsh
+++ b/vertex_program/a_lava_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/a_membrane_cbmp_ps20.vsh
+++ b/vertex_program/a_membrane_cbmp_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/a_nolighting.vsh
+++ b/vertex_program/a_nolighting.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_nolighting_masked_vcolor_vs11.vsh
+++ b/vertex_program/a_nolighting_masked_vcolor_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_nolighting_vcolor_vs11.vsh
+++ b/vertex_program/a_nolighting_vcolor_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_replace0_decal_vs11.vsh
+++ b/vertex_program/a_replace0_decal_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetREP0	textureCoordinateSet1

--- a/vertex_program/a_replace0_decal_vs20.vsh
+++ b/vertex_program/a_replace0_decal_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetREP0	textureCoordinateSet1

--- a/vertex_program/a_replace0_specmap_decal_vs11.vsh
+++ b/vertex_program/a_replace0_specmap_decal_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetREP0	textureCoordinateSet1

--- a/vertex_program/a_replace0_specmap_decal_vs20.vsh
+++ b/vertex_program/a_replace0_specmap_decal_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetREP0	textureCoordinateSet1

--- a/vertex_program/a_scroll.vsh
+++ b/vertex_program/a_scroll.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_scroll_rgb1_a2.vsh
+++ b/vertex_program/a_scroll_rgb1_a2.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_simple.vsh
+++ b/vertex_program/a_simple.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_simple_bump.vsh
+++ b/vertex_program/a_simple_bump.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/a_simple_bump_decal_vs11.vsh
+++ b/vertex_program/a_simple_bump_decal_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDCAL	textureCoordinateSet1

--- a/vertex_program/a_simple_bump_decal_vs20.vsh
+++ b/vertex_program/a_simple_bump_decal_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDCAL	textureCoordinateSet1

--- a/vertex_program/a_simple_bump_vs11_for_ps11.vsh
+++ b/vertex_program/a_simple_bump_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/a_simple_bump_vs20.vsh
+++ b/vertex_program/a_simple_bump_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/a_simple_bump_vs20_for_ps20.vsh
+++ b/vertex_program/a_simple_bump_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/a_simple_decal_vs11.vsh
+++ b/vertex_program/a_simple_decal_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDCAL	textureCoordinateSet1

--- a/vertex_program/a_simple_openuv_vs11.vsh
+++ b/vertex_program/a_simple_openuv_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetOPEN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_simple_openuv_vs20_for_ps20.vsh
+++ b/vertex_program/a_simple_openuv_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetOPEN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_simple_rimlight.vsh
+++ b/vertex_program/a_simple_rimlight.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_simple_vs11.vsh
+++ b/vertex_program/a_simple_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_simple_vs20_for_ps20.vsh
+++ b/vertex_program/a_simple_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_spec.vsh
+++ b/vertex_program/a_spec.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_spec_pp_vs20_for_ps20.vsh
+++ b/vertex_program/a_spec_pp_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_spec_vcolor_vs20_nodot3.vsh
+++ b/vertex_program/a_spec_vcolor_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_spec_vs11.vsh
+++ b/vertex_program/a_spec_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_spec_vs20_nodot3.vsh
+++ b/vertex_program/a_spec_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_specmap_aniso_detail_vs20_nodot3.vsh
+++ b/vertex_program/a_specmap_aniso_detail_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_specmap_aniso_vs11.vsh
+++ b/vertex_program/a_specmap_aniso_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_specmap_aniso_vs20.vsh
+++ b/vertex_program/a_specmap_aniso_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_specmap_aniso_vs20_nodot3.vsh
+++ b/vertex_program/a_specmap_aniso_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_specmap_aniso_vs20_notdot3.vsh
+++ b/vertex_program/a_specmap_aniso_vs20_notdot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_specmap_bump_detail_vs20.vsh
+++ b/vertex_program/a_specmap_bump_detail_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_specmap_bump_vcolor_vs11.vsh
+++ b/vertex_program/a_specmap_bump_vcolor_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/a_specmap_bump_vcolor_vs20.vsh
+++ b/vertex_program/a_specmap_bump_vcolor_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/a_specmap_bump_vs11_for_ps11.vsh
+++ b/vertex_program/a_specmap_bump_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/a_specmap_bump_vs20.vsh
+++ b/vertex_program/a_specmap_bump_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/a_specmap_bump_vs20_for_ps20.vsh
+++ b/vertex_program/a_specmap_bump_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/a_specmap_detail_vs20_nodot3.vsh
+++ b/vertex_program/a_specmap_detail_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/a_specmap_vcolor_vs11.vsh
+++ b/vertex_program/a_specmap_vcolor_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_specmap_vs11_for_ps11.vsh
+++ b/vertex_program/a_specmap_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_specmap_vs20_dot3.vsh
+++ b/vertex_program/a_specmap_vs20_dot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_specmap_vs20_nodot3.vsh
+++ b/vertex_program/a_specmap_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_specmap_vs20_notdot3.vsh
+++ b/vertex_program/a_specmap_vs20_notdot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_vertexlit.vsh
+++ b/vertex_program/a_vertexlit.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_vertexlit_fog_gradient.vsh
+++ b/vertex_program/a_vertexlit_fog_gradient.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_vertexlit_no_fog.vsh
+++ b/vertex_program/a_vertexlit_no_fog.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/a_vertexlit_position_20.vsh
+++ b/vertex_program/a_vertexlit_position_20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/bad_vertex_shader.vsh
+++ b/vertex_program/bad_vertex_shader.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/c_simple_vs11.vsh
+++ b/vertex_program/c_simple_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/c_spec_pp_vs20.vsh
+++ b/vertex_program/c_spec_pp_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/c_spec_vs20_nodot3.vsh
+++ b/vertex_program/c_spec_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/c_specmap_vs11.vsh
+++ b/vertex_program/c_specmap_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/dot3_terrain_imp1.vsh
+++ b/vertex_program/dot3_terrain_imp1.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/dot3_terrain_imp2.vsh
+++ b/vertex_program/dot3_terrain_imp2.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/e_bloom_mask_pass_vs20.vsh
+++ b/vertex_program/e_bloom_mask_pass_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet.vsh
+++ b/vertex_program/e_planet.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_cloud_simple_vs11.vsh
+++ b/vertex_program/e_planet_cloud_simple_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_cloud_smalltile.vsh
+++ b/vertex_program/e_planet_cloud_smalltile.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_cloud_sml_tile.vsh
+++ b/vertex_program/e_planet_cloud_sml_tile.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_cloudtile.vsh
+++ b/vertex_program/e_planet_cloudtile.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_cloudtile_lok.vsh
+++ b/vertex_program/e_planet_cloudtile_lok.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_cloudtile_lrg_amb.vsh
+++ b/vertex_program/e_planet_cloudtile_lrg_amb.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_cloudtile_sml.vsh
+++ b/vertex_program/e_planet_cloudtile_sml.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_dantooine.vsh
+++ b/vertex_program/e_planet_dantooine.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_detail.vsh
+++ b/vertex_program/e_planet_detail.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_detail_lok.vsh
+++ b/vertex_program/e_planet_detail_lok.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_detail_vs11.vsh
+++ b/vertex_program/e_planet_detail_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/e_planet_far_detail.vsh
+++ b/vertex_program/e_planet_far_detail.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 

--- a/vertex_program/e_planet_kessel.vsh
+++ b/vertex_program/e_planet_kessel.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_simple_vs11.vsh
+++ b/vertex_program/e_planet_simple_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_tatooine.vsh
+++ b/vertex_program/e_planet_tatooine.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_tile.vsh
+++ b/vertex_program/e_planet_tile.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_tile4.vsh
+++ b/vertex_program/e_planet_tile4.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_tile4_singlelight.vsh
+++ b/vertex_program/e_planet_tile4_singlelight.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_tile_corl.vsh
+++ b/vertex_program/e_planet_tile_corl.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_planet_tile_singlelight.vsh
+++ b/vertex_program/e_planet_tile_singlelight.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/e_screenshader.vsh
+++ b/vertex_program/e_screenshader.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/h_alpha_color2_envmask_specmap_vs11.vsh
+++ b/vertex_program/h_alpha_color2_envmask_specmap_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/h_alpha_color2_envmask_vs11.vsh
+++ b/vertex_program/h_alpha_color2_envmask_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/h_alpha_color2_specmap_aniso_vs11.vsh
+++ b/vertex_program/h_alpha_color2_specmap_aniso_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/h_alpha_color2_vs11.vsh
+++ b/vertex_program/h_alpha_color2_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/h_color2_detail_specmap_vs11_for_ps11.vsh
+++ b/vertex_program/h_color2_detail_specmap_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/h_color2_detail_specmap_vs20.vsh
+++ b/vertex_program/h_color2_detail_specmap_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/h_color2_detail_specmap_vs20_nodot3.vsh
+++ b/vertex_program/h_color2_detail_specmap_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/h_color2_envmask_specmap_emismap_vs11.vsh
+++ b/vertex_program/h_color2_envmask_specmap_emismap_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/h_color2_envmask_specmap_emismap_vs20_nodot3.vsh
+++ b/vertex_program/h_color2_envmask_specmap_emismap_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/h_color2w_bump_c20_ps11_pass1.vsh
+++ b/vertex_program/h_color2w_bump_c20_ps11_pass1.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/h_color2w_bump_detail_vs11_for_ps11_pass1.vsh
+++ b/vertex_program/h_color2w_bump_detail_vs11_for_ps11_pass1.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/h_color2w_bump_for_ps20.vsh
+++ b/vertex_program/h_color2w_bump_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetDOT3	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/h_color2w_bump_vs11_for_ps11_pass1.vsh
+++ b/vertex_program/h_color2w_bump_vs11_for_ps11_pass1.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/h_color2w_bump_vs20_for_ps20.vsh
+++ b/vertex_program/h_color2w_bump_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetDOT3	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/h_color2w_envmask_specmap_vs11.vsh
+++ b/vertex_program/h_color2w_envmask_specmap_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/h_color2w_for_ps11.vsh
+++ b/vertex_program/h_color2w_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/h_color2w_specmap_aniso_vs11.vsh
+++ b/vertex_program/h_color2w_specmap_aniso_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/h_color2w_specmap_detail_vs11_for_ps11.vsh
+++ b/vertex_program/h_color2w_specmap_detail_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDETA	textureCoordinateSet1

--- a/vertex_program/h_color2w_specmap_emismap_vs11_for_ps11.vsh
+++ b/vertex_program/h_color2w_specmap_emismap_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/h_color2w_specmap_emismap_vs20_for_ps20.vsh
+++ b/vertex_program/h_color2w_specmap_emismap_vs20_for_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/h_color2w_specmap_vs11_for_ps11.vsh
+++ b/vertex_program/h_color2w_specmap_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/h_color2w_specmap_vs20_nodot3.vsh
+++ b/vertex_program/h_color2w_specmap_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/h_color2w_vs11_for_ps11.vsh
+++ b/vertex_program/h_color2w_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/holonet_ps20.vsh
+++ b/vertex_program/holonet_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/holonet_zwrite_ps20.vsh
+++ b/vertex_program/holonet_zwrite_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/membrane.vsh
+++ b/vertex_program/membrane.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/membrane_hologram_ps20.vsh
+++ b/vertex_program/membrane_hologram_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/membrane_hologram_zwrite_mask_ps20.vsh
+++ b/vertex_program/membrane_hologram_zwrite_mask_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/no_lighting.vsh
+++ b/vertex_program/no_lighting.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/ps11_bump_diffuse_pass.vsh
+++ b/vertex_program/ps11_bump_diffuse_pass.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetDOT3	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/saber_blade.vsh
+++ b/vertex_program/saber_blade.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/simple_amt1c_le.vsh
+++ b/vertex_program/simple_amt1c_le.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/simple_bump_emismap_pass_vs11_for_ps11.vsh
+++ b/vertex_program/simple_bump_emismap_pass_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/simple_bump_light_pass_vs11_for_ps11.vsh
+++ b/vertex_program/simple_bump_light_pass_vs11_for_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetDOT3	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/skybox.vsh
+++ b/vertex_program/skybox.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/skybox_6sided.vsh
+++ b/vertex_program/skybox_6sided.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/spec_light_pass_pp_vs20.vsh
+++ b/vertex_program/spec_light_pass_pp_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/spec_light_pass_vs11.vsh
+++ b/vertex_program/spec_light_pass_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/specmap_aniso_light_pass_vs11.vsh
+++ b/vertex_program/specmap_aniso_light_pass_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/specmap_aniso_light_pass_vs20.vsh
+++ b/vertex_program/specmap_aniso_light_pass_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/specmap_aniso_light_pass_vs20_nodot3.vsh
+++ b/vertex_program/specmap_aniso_light_pass_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/specmap_bump_light_pass_vs11.vsh
+++ b/vertex_program/specmap_bump_light_pass_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/specmap_bump_light_pass_vs20.vsh
+++ b/vertex_program/specmap_bump_light_pass_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetNRML	textureCoordinateSet1

--- a/vertex_program/specmap_dirt_light_pass_vs11.vsh
+++ b/vertex_program/specmap_dirt_light_pass_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetDIRT	textureCoordinateSet1

--- a/vertex_program/specmap_light_pass_pp_vs20.vsh
+++ b/vertex_program/specmap_light_pass_pp_vs20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/specmap_light_pass_vs11.vsh
+++ b/vertex_program/specmap_light_pass_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/specmap_light_pass_vs20_nodot3.vsh
+++ b/vertex_program/specmap_light_pass_vs20_nodot3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/stars.vsh
+++ b/vertex_program/stars.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/terrain_dot3_vs20_blend0.vsh
+++ b/vertex_program/terrain_dot3_vs20_blend0.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/terrain_dot3_vs20_blend0_spec.vsh
+++ b/vertex_program/terrain_dot3_vs20_blend0_spec.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/terrain_dot3_vs20_blend1.vsh
+++ b/vertex_program/terrain_dot3_vs20_blend1.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/terrain_dot3_vs20_blend1_spec.vsh
+++ b/vertex_program/terrain_dot3_vs20_blend1_spec.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/terrain_dot3_vs20_blend2.vsh
+++ b/vertex_program/terrain_dot3_vs20_blend2.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/terrain_dot3_vs20_blend2_spec.vsh
+++ b/vertex_program/terrain_dot3_vs20_blend2_spec.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/terrain_dot3_vs20_blend3.vsh
+++ b/vertex_program/terrain_dot3_vs20_blend3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/terrain_dot3_vs20_blend3_spec.vsh
+++ b/vertex_program/terrain_dot3_vs20_blend3_spec.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/terrain_vs20_blend0.vsh
+++ b/vertex_program/terrain_vs20_blend0.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/terrain_vs20_blend1.vsh
+++ b/vertex_program/terrain_vs20_blend1.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/terrain_vs20_blend2.vsh
+++ b/vertex_program/terrain_vs20_blend2.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/terrain_vs20_blend3.vsh
+++ b/vertex_program/terrain_vs20_blend3.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/texren_blend2-overwrite_c1a1_c2a2.vsh
+++ b/vertex_program/texren_blend2-overwrite_c1a1_c2a2.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetBLN0	textureCoordinateSet0
 #define textureCoordinateSetBLN1	textureCoordinateSet1

--- a/vertex_program/texren_copy_c1a1.vsh
+++ b/vertex_program/texren_copy_c1a1.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/ui.vsh
+++ b/vertex_program/ui.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/ui_membrane_color2_ps11.vsh
+++ b/vertex_program/ui_membrane_color2_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/ui_membrane_color2_ps20.vsh
+++ b/vertex_program/ui_membrane_color2_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/ui_nolighting_vcolor_vs11.vsh
+++ b/vertex_program/ui_nolighting_vcolor_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/ui_radar.vsh
+++ b/vertex_program/ui_radar.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define textureCoordinateSetALPH	textureCoordinateSet1

--- a/vertex_program/vertex_color.vsh
+++ b/vertex_program/vertex_color.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/vertex_color_lighting.vsh
+++ b/vertex_program/vertex_color_lighting.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/vertex_heat_render.vsh
+++ b/vertex_program/vertex_heat_render.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/vertex_lava_heat_render.vsh
+++ b/vertex_program/vertex_lava_heat_render.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/video_blit.vsh
+++ b/vertex_program/video_blit.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #define textureCoordinateSetMAIN	textureCoordinateSet0
 #define DECLARE_textureCoordinateSets	\

--- a/vertex_program/water_lava02_vs11.vsh
+++ b/vertex_program/water_lava02_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"
 

--- a/vertex_program/water_lava_textured_vs11.vsh
+++ b/vertex_program/water_lava_textured_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"
 

--- a/vertex_program/water_lava_vs11.vsh
+++ b/vertex_program/water_lava_vs11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"
 

--- a/vertex_program/water_pass1.vsh
+++ b/vertex_program/water_pass1.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/water_pass2_20.vsh
+++ b/vertex_program/water_pass2_20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/water_pass2_25.vsh
+++ b/vertex_program/water_pass2_25.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1 vs_2_0
+//hlsl vs_1_1 vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/water_pass2_ps20.vsh
+++ b/vertex_program/water_pass2_ps20.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_2_0
+//hlsl vs_2_0 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/zwrite_mask_ps11.vsh
+++ b/vertex_program/zwrite_mask_ps11.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"

--- a/vertex_program/zwrite_mask_ps20_falloff.vsh
+++ b/vertex_program/zwrite_mask_ps20_falloff.vsh
@@ -1,4 +1,4 @@
-//hlsl vs_1_1
+//hlsl vs_1_1 vs_3_0
 
 #include "vertex_program/include/vertex_shader_constants.inc"
 #include "vertex_program/include/functions.inc"


### PR DESCRIPTION
## Summary
- append the vs_3_0 shader model profile to every vertex shader compile directive so the pipeline can target the highest DirectX 9 capability

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5080f83a8832c85a736670202fc67