### PR TITLE
Refine DX9 shared shader helpers for SM3 compatibility

### DIFF
--- a/shared_program/functions.inc
+++ b/shared_program/functions.inc
@@ -1,9 +1,26 @@
 // ======================================================================
 // functions_dx9_ultimate.inc
-// Ultimate DX9 Shader Utility Pack (SM3.0-Optimized)
-// Max Quality: Full lighting, material decoding, normal handling
-// Compatible with SWG and high-end DX9 visuals
+// Utility helpers tuned for Shader Model 3.0 (DirectX 9)
+// Focused on predictable ALU usage and compatibility with SWG's renderer
 // ======================================================================
+
+static const float SMALL_EPSILON = 1.0e-6f;
+
+// ----------------------------------------------------------------------
+// texture access helpers ------------------------------------------------
+// Provide a single entry point for SM3.0 vertex and pixel shaders. When
+// compiling as a vertex shader we fall back to tex2Dlod which is available
+// in vs_3_0, while pixel shaders keep the hardware filtered tex2D path.
+// ----------------------------------------------------------------------
+
+float4 sampleTextureDX9(sampler2D map, float2 uv)
+{
+#if defined(VERTEX_SHADER_VERSION) && (VERTEX_SHADER_VERSION >= 30)
+    return tex2Dlod(map, float4(uv, 0.0f, 0.0f));
+#else
+    return tex2D(map, uv);
+#endif
+}
 
 // -------------------- BASIC MATH --------------------
 
@@ -24,7 +41,8 @@ float3 reverseSignAndBias(float3 v)
 
 float3 fastNormalize(float3 v)
 {
-    return v * rsqrt(dot(v, v) + 1e-6f);
+    float lenSq = max(dot(v, v), SMALL_EPSILON);
+    return v * rsqrt(lenSq);
 }
 
 // -------------------- NORMAL DECODING --------------------
@@ -38,7 +56,7 @@ float3 decodeNormalRG(float2 enc)
 
 float3 decodeNormalDXT5(sampler2D map, float2 uv)
 {
-    float4 px = tex2D(map, uv);
+    float4 px = sampleTextureDX9(map, uv);
     float2 xy = (float2(px.a, px.g) - 0.5f) * 2.0f;
     float z = sqrt(saturate(1.0f - dot(xy, xy)));
     return float3(xy, z);
@@ -46,24 +64,32 @@ float3 decodeNormalDXT5(sampler2D map, float2 uv)
 
 float3 decodeNormalDXT5Fast(sampler2D map, float2 uv)
 {
-    float4 px = tex2D(map, uv);
+    float4 px = sampleTextureDX9(map, uv);
     float2 xy = (float2(px.a, px.g) - 0.5f) * 2.0f;
     float d = dot(xy, xy);
-    float z = lerp(d * 1.6667f + 0.15f, d * 0.6667f + 0.375f, step(0.24f, d));
+    float useHighCurve = (d >= 0.24f) ? 1.0f : 0.0f;
+    float zHigh = d * 1.6667f + 0.15f;
+    float zLow  = d * 0.6667f + 0.375f;
+    float z = lerp(zLow, zHigh, useHighCurve);
     return fastNormalize(float3(xy, z));
 }
 
 float3 computeNormalFromHeight(sampler2D heightMap, float2 uv, float scale)
 {
-    float hL = tex2D(heightMap, uv + float2(-scale, 0)).r;
-    float hR = tex2D(heightMap, uv + float2(scale, 0)).r;
-    float hD = tex2D(heightMap, uv + float2(0, -scale)).r;
-    float hU = tex2D(heightMap, uv + float2(0, scale)).r;
-    float3 n = normalize(float3(hL - hR, hD - hU, 2.0f * scale));
-    return n;
+    float hL = sampleTextureDX9(heightMap, uv + float2(-scale, 0.0f)).r;
+    float hR = sampleTextureDX9(heightMap, uv + float2( scale, 0.0f)).r;
+    float hD = sampleTextureDX9(heightMap, uv + float2(0.0f, -scale)).r;
+    float hU = sampleTextureDX9(heightMap, uv + float2(0.0f,  scale)).r;
+    float3 n = float3(hL - hR, hD - hU, 2.0f * scale);
+    return fastNormalize(n);
 }
 
 // -------------------- LIGHTING --------------------
+
+float safePow(float base, float exponent)
+{
+    return pow(saturate(base), exponent);
+}
 
 // Full Blinn-Phong lighting with Fresnel and ambient occlusion
 float3 computeLighting(
@@ -76,11 +102,14 @@ float3 computeLighting(
     float ao
 )
 {
-    float3 halfDir = normalize(lightDir + viewDir);
-    float diff = saturate(dot(normal, lightDir));
-    float spec = pow(saturate(dot(normal, halfDir)), gloss * 128.0f);
-    float fresnel = pow(1.0f - saturate(dot(viewDir, normal)), 5.0f);
-    float3 specColor = lerp(1.0f.xxx, lightColor, metalness);
+    float3 n = fastNormalize(normal);
+    float3 l = fastNormalize(lightDir);
+    float3 v = fastNormalize(viewDir);
+    float3 halfDir = fastNormalize(l + v);
+    float diff = saturate(dot(n, l));
+    float spec = safePow(dot(n, halfDir), max(gloss * 128.0f, 1.0f));
+    float fresnel = safePow(1.0f - saturate(dot(v, n)), 5.0f);
+    float3 specColor = lerp(float3(1.0f, 1.0f, 1.0f), lightColor, saturate(metalness));
     float3 final = (diff * lightColor + spec * specColor * fresnel) * ao;
     return final;
 }
@@ -119,13 +148,13 @@ float3 toneMapReinhard(float3 color)
 // Detail normal map blending
 float3 blendNormals(float3 base, float3 detail)
 {
-    base = normalize(base);
-    detail = normalize(detail);
+    base = fastNormalize(base);
+    detail = fastNormalize(detail);
     float3 up = float3(0.0f, 0.0f, 1.0f);
-    float3 t = normalize(cross(up, base));
+    float3 t = fastNormalize(cross(up, base));
     float3 b = cross(base, t);
     float3x3 TBN = float3x3(t, b, base);
-    return normalize(mul(detail, TBN));
+    return fastNormalize(mul(detail, TBN));
 }
 
 // ======================================================================


### PR DESCRIPTION
## Summary
- add a DX9 texture sampling helper that picks tex2Dlod for SM3 vertex shaders
- harden shared math utilities with safe normalization and power helpers
- update normal decoding and lighting functions to use the new helpers for consistent vs_3_0 behaviour

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5095f7b10832c8f84684ae87f3bca