### PR TITLE
Define extended light data constants

### DIFF
--- a/vertex_program/include/vertex_shader_constants.inc
+++ b/vertex_program/include/vertex_shader_constants.inc
@@ -58,6 +58,18 @@ struct DiffuseSpecular
 	float4	specular;
 };
 
+struct ExtendedParallelSpecularLight
+{
+	float4	tangentColor;
+	float4	tangentMinusDiffuse;
+	float4	tangentMinusBack;
+};
+
+struct ExtendedLightData
+{
+	ExtendedParallelSpecularLight parallelSpecular[NumberOfParallelSpecularLights];
+};
+
 static const int NumberOfParallelSpecularLights = 1;
 static const int NumberOfParallelLights         = 2;
 static const int NumberOfPointSpecularLights    = 1;
@@ -88,6 +100,7 @@ float4    fog : register(c10);
 
 Material  material : register(c11);
 LightData lightData : register(c16);
+ExtendedLightData extLightData : register(c60);
 
 float4    textureFactor : register(c44);
 float4    textureFactor2 : register(c45);

--- a/vertex_program/modules/registers.inc
+++ b/vertex_program/modules/registers.inc
@@ -65,6 +65,9 @@
 #define cUserConstant5                                c57
 #define cUserConstant6                                c58
 #define cUserConstant7                                c59
+#define cExtLtData_parallelSpec_0_tangentColor         c60
+#define cExtLtData_parallelSpec_0_tangentMinusDiffuse  c61
+#define cExtLtData_parallelSpec_0_tangentMinusBack     c62
 #define c0_0                                          c95.x
 #define c0_5                                          c95.y
 #define c1_0                                          c95.z


### PR DESCRIPTION
## Summary
- add extended light data structs to the vertex shader constant layout so tangent lighting registers are defined
- expose the extended parallel specular light constants via register aliases for assembly modules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d512a4e410832ca4917b24dc93218a